### PR TITLE
[#5] Provide 2 sorts of compilation: ORANGE and normal (from Qt Creator sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,36 @@
 
 The qmljsreformatter tool allows to automatically format a QML file via a command-line interface. It is based on a functionality embedded in the Qt Creator IDE.
 
+This project supports two versions of qmljsreformatter:
+* The original version whose the source code comes from Qt Creator.
+* The Orange version which is a modified version of the Qt Creator source code, which:
+  * allows to split (or not) the long lines.
+  * adds automatically semicolons (`;`) at the end of the JavaScript statements.
+
 ## How to build qmljsreformatter as a standalone binary
 
 Download at least the Qt 5.8 source version: https://download.qt.io/archive/qt/5.8/5.8.0/single/qt-everywhere-opensource-src-5.8.0.tar.gz.mirrorlist
 
 Build Qt 5.8 sources:
-```
-$ tar xf qt-everywhere-opensource-src-5.8.0.tar.gz
-$ cd qt-everywhere-opensource-src-5.8.0
-$ ./configure -prefix {SOMEWHERE}/Qt5.8.0.static -opensource -static -skip wayland -no-egl -nomake examples
-$ make -j 4 (or more jobs if it is possible)
-$ make install
+```bash
+tar xf qt-everywhere-opensource-src-5.8.0.tar.gz
+cd qt-everywhere-opensource-src-5.8.0
+./configure -prefix {SOMEWHERE}/Qt5.8.0.static -opensource -static -skip wayland -no-egl -nomake examples
+make -j 4 # (or more jobs if possible)
+make install
 ```
 
-Build qmljsreformatter:
-```
-$ cd qmljsreformatter
-$ mkdir build && cd build
-$ {SOMEWHERE}/Qt5.8.0.static/bin/qmake .. 
-$ make -j 4
+Build qmljsreformatter
+```bash
+cd qmljsreformatter
+mkdir build && cd build
+
+# Original (from Qt Creator source code) version of qmljsreformatter
+{SOMEWHERE}/Qt5.8.0.static/bin/qmake ..
+# or the Orange version
+# $ {SOMEWHERE}/Qt5.8.0.static/bin/qmake .. CONFIG+=ORANGE
+
+make -j 4 # (or more jobs if possible)
 ```
 
 ## How to use qmljsreformatter
@@ -29,28 +40,42 @@ Considering the following _Example.qml_ file:
 
 ```qml
 // Example.qml
-import QtQuick 2.5
+import QtQuick 2.0
 Item{property int id:5;Component.onCompleted:{console.log("Completed!")}
                        }
 ```
 
 Run _qmljsreformatter_ to create a new file:
 
-```
-$ ./qmljsreformatter Example.qml Example.new.qml
+```bash
+./qmljsreformatter Example.qml Example.new.qml
 ```
 
 or to overwrite the source file:
 
-```
-$ ./qmljsreformatter Example.qml Example.qml
+```bash
+./qmljsreformatter Example.qml Example.qml
 ```
 
-The resulting file will contain:
+The resulting file will be reformatted that way:
 
 ```qml
 // Example.qml
-import QtQuick 2.5
+import QtQuick 2.0
+
+Item {
+    property int id: 5
+    Component.onCompleted: {
+        console.log("Completed!")
+    }
+}
+```
+
+**Note**: If qmljsreformatter has been built with the Orange configuration, the resulting file will have semicolons (`;`) at the end of all the JavaScript statements. This last will then be reformatted that way:
+
+```qml
+// Example.qml
+import QtQuick 2.0
 
 Item {
     property int id: 5
@@ -62,15 +87,17 @@ Item {
 
 ## How to run the tests
 
-```
-$ cd qmljsreformatter/tests
-$ ./run-tests.sh
+The tests are only valid if qmljsreformatter is compiled with the Orange configuration.
+
+```bash
+cd qmljsreformatter/tests
+./run-tests.sh
 ```
 
 It is also possible to run a specific test. The following commands will execute the tests contained in of the Header.test.qml file.
 
-```
-$ cd qmljsreformatter/tests
-$ ./run-test.sh Header
+```bash
+cd qmljsreformatter/tests
+./run-test.sh Header
 [OK] Header.test.qml
 ```

--- a/qmljsreformatter.pro
+++ b/qmljsreformatter.pro
@@ -11,17 +11,19 @@ QT_CREATOR_SIMPLIFIED_SRC = "qt-creator-simplified"
 INCLUDEPATH += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs
 INCLUDEPATH += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty
 
-HEADERS += src/qmljsreformatter.h \ # src/qmljsreformatter.h overrides the original header
+HEADERS += \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/cppmodelmanagerbase.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/filesystemwatcher.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/savefile.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/optional.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljscodeformatter.h \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsinterpreter.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsmodelmanagerinterface.h \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsplugindumper.h \
-    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsinterpreter.h
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsreformatter.h
 
-SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/AST.cpp \
+SOURCES += \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/AST.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/ASTClone.cpp \ 
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/ASTMatch0.cpp \ 
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/ASTMatcher.cpp \
@@ -54,7 +56,8 @@ SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/AST.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/Type.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/3rdparty/cplusplus/TypeVisitor.cpp \ 
 
-SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/CppDocument.cpp \
+SOURCES += \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/CppDocument.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/cppmodelmanagerbase.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/CppRewriter.cpp \  
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/DependencyTable.cpp \
@@ -73,7 +76,8 @@ SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/CppDocument.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/TypeOfExpression.cpp \ 
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/cplusplus/TypePrettyPrinter.cpp \ 
 
-SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/environment.cpp \ 
+SOURCES += \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/environment.cpp \ 
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/fileutils.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/filesystemwatcher.cpp \ 
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/hostosinfo.cpp \
@@ -82,10 +86,12 @@ SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/environment.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/runextensions.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/utils/savefile.cpp
 
-SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/languageutils/componentversion.cpp \
+SOURCES += \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/languageutils/componentversion.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/languageutils/fakemetaobject.cpp
 
-SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmlerror.cpp \
+SOURCES += \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmlerror.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmljsast.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmljsastvisitor.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmldirparser.cpp \
@@ -107,9 +113,7 @@ SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmlerror.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsmodelmanagerinterface.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsplugindumper.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsqrcparser.cpp \
-#   src/qmljsreformatter.cpp overrides this original file
-#   $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsreformatter.cpp \
-    src/qmljsreformatter.cpp \
+    $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsreformatter.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsscanner.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsscopeastpath.cpp \
     $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsscopebuilder.cpp \
@@ -121,7 +125,16 @@ SOURCES += $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/parser/qmlerror.cpp \
 
 SOURCES += src/main.cpp
 
+ORANGE {
+    DEFINES += ORANGE
+    
+    # Override the code source from Qt Creator
+    SOURCES -= $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsreformatter.cpp
+    HEADERS -= $$QT_CREATOR_SIMPLIFIED_SRC/src/libs/qmljs/qmljsreformatter.h
+    SOURCES += src/qmljsreformatter.cpp
+    HEADERS += src/qmljsreformatter.h
+}
+
 TARGET = qmljsreformatter
 
 OTHER_FILES += tests/*.test.qml tests/*.reference.qml tests/*.sh
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,11 @@
 #include <QDebug>
 #include <QFile>
 
-#include "src/qmljsreformatter.h"
+#ifdef ORANGE
+#include "qmljsreformatter.h"
+#else
+#include "qmljs/qmljsreformatter.h"
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -36,15 +40,21 @@ int main(int argc, char *argv[])
     parser.addVersionOption();
     parser.addPositionalArgument("source", "Source file.");
     parser.addPositionalArgument("destination", "Destination file.");
+#ifdef ORANGE
     // A boolean option with multiple names (-s, --split)
     QCommandLineOption splitOption(QStringList() << "s" << "split", "Split the long lines.");
     parser.addOption(splitOption);
+#endif
     parser.process(app);
 
     const QStringList args = parser.positionalArguments();
 
     if (args.length() < 2) {
+#ifdef ORANGE
+        qWarning() << "Usage:" << argv[0] << "[-s|--split] <input-file> <output-file>";
+#else
         qWarning() << "Usage:" << argv[0] << "<input-file> <output-file>";
+#endif
         return 1;
     }
 
@@ -78,7 +88,12 @@ int main(int argc, char *argv[])
         return 3;
     }
 
+#ifdef ORANGE
     QString formattedContent = QmlJS::reformat(doc, parser.isSet(splitOption));
+#else
+    QString formattedContent = QmlJS::reformat(doc);
+#endif
+
     QFile outFile(outputFile);
 
     if (outFile.open(QIODevice::WriteOnly)) {


### PR DESCRIPTION
**How to test:**

Create a _Test.qml_ file under the _build_ directory containing:

```qml
import QtQuick 2.0
Item{property int id:5;Component.onCompleted:{console.log("Completed!")}
                       }
```

Compile and execute the normal version of qmljsreformatter:

```bash
cd build
# Note: use your own configuration, here is mine:
make distclean ; /Users/ju/Qt5.12.0.static/bin/qmake .. ; make -j 16
./qmljsreformatter Test.qml Test.toto.qml ; cat Test.toto.qml
```

The resulting file must contain:

```qml
import QtQuick 2.0

Item {
    property int id: 5
    Component.onCompleted: {
        console.log("Completed!")
    }
}
```

Compile and execute the Orange version of qmljsreformatter:

```bash
cd build
# Note: use your own configuration, here is mine:
make distclean ; /Users/ju/Qt5.12.0.static/bin/qmake .. CONFIG+=ORANGE ; make -j 16
./qmljsreformatter Test.qml Test.toto.qml ; cat Test.toto.qml
```

The resulting file must contain:

```qml
import QtQuick 2.0

Item {
    property int id: 5
    Component.onCompleted: {
        console.log("Completed!");
    }
}
```

closes #5 